### PR TITLE
add resolvers for project on job and job on task

### DIFF
--- a/server/src/resolvers/Job.js
+++ b/server/src/resolvers/Job.js
@@ -1,0 +1,9 @@
+const Job = {
+  project: ({ projectId }, args, context) => {
+    return context.prisma.project({ id: projectId })
+  },
+}
+
+module.exports = {
+  Job,
+}

--- a/server/src/resolvers/Task.js
+++ b/server/src/resolvers/Task.js
@@ -1,0 +1,9 @@
+const Task = {
+  job: ({ jobId }, args, context) => {
+    return context.prisma.project({ id: jobId })
+  },
+}
+
+module.exports = {
+  Task,
+}

--- a/server/src/resolvers/index.js
+++ b/server/src/resolvers/index.js
@@ -6,6 +6,8 @@ const { task } = require('./Mutation/task')
 const { User } = require('./User')
 const { Project } = require('./Project')
 const { job } = require('./Mutation/job')
+const { Job } = require('./Job')
+const { Task } = require('./Task')
 
 module.exports = {
   Query,
@@ -18,4 +20,6 @@ module.exports = {
   },
   User,
   Project,
+  Job,
+  Task,
 }

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -95,6 +95,7 @@ type Job {
   startDateTime: String!
   endDateTime: String
   fileIds: [String]
+  project: Project!
 }
 
 type Task {
@@ -106,6 +107,7 @@ type Task {
   fileId: String
   type: ProjectType
   labels: [Label]
+  job: Job!
 }
 
 type Label {


### PR DESCRIPTION
Enable nested gql calls to do things like:
```
getTask {
  id
  job  {
    project {
    }
  }
{
```