### PR TITLE
fix bug not showing completion UI after final image

### DIFF
--- a/src/pages/TaskPage/index.js
+++ b/src/pages/TaskPage/index.js
@@ -106,8 +106,6 @@ const TaskPage = ({ ...props }) => {
 
   const { refetch: nextTask } = nextTaskData;
 
-  console.log({ nextTaskData });
-
   const submitTask = useMutation(SUBMIT_TASK);
 
   if (nextTaskData.error) console.log('error loading task', nextTaskData.error);


### PR DESCRIPTION
**Issue**

Close #97

**Description**
- Add check for error to hinting that it is the last image to annotate

**Screenshots**
![sol](https://user-images.githubusercontent.com/44876556/61130115-85764780-a4e8-11e9-9961-fd2213fd9368.gif)


**Notes**
- Watching the `gif` above, there is a graphQL error from the server even `data` property of the return object is not null. The error occurs when it is the last image to be annotated, it looks like server is still sending a data even is generating an error